### PR TITLE
Fix technology constants in switch in iframe.php

### DIFF
--- a/iframe.php
+++ b/iframe.php
@@ -318,17 +318,17 @@ if ($controls !== '0') {
     }
     echo '<select class = "jmolPanelControl" id = "use" title = "'.get_string('displaytechnology', 'filter_jmol', true).'">';
     switch ($technol){
-        case HTML5:
+        case 'HTML5':
             echo '<option title = "JSmol using HTML5" value = "HTML5" selected = "selected">JSmol</option>';
             echo '<option title = "GLmol using WebGL" value = "WEBGL">GLmol</option>';
             echo '<option title = "Jmol using Java" value = "SIGNED">Jmol</option>';
         break;
-        case WEBGL:
+        case 'WEBGL':
             echo '<option title = "JSmol using HTML5" value = "HTML5">JSmol</option>';
             echo '<option title = "GLmol using WebGL" value = "WEBGL"selected = "selected">GLmol</option>';
             echo '<option title = "Jmol using Java" value = "SIGNED">Jmol</option>';
         break;
-        case SIGNED:
+        case 'SIGNED':
             echo '<option title = "JSmol using HTML5" value = "HTML5">JSmol</option>';
             echo '<option title = "GLmol using WebGL" value = "WEBGL">GLmol</option>';
             echo '<option title = "Jmol using Java" value = "SIGNED" selected = "selected">Jmol</option>';


### PR DESCRIPTION
In iframe.php, bare text 'case HTML5' is used inside a switch
statement. This is incorrect as there is no 'HTML5' constant
defined in the code. It needs quotes around the 'HTML5'.

It works correctly already because PHP defaults to treating an
unrecognised constant as the same as the string. However, this
causes warning messages in the PHP log.