### PR TITLE
allow water molecule to be displayed on init load

### DIFF
--- a/iframe.php
+++ b/iframe.php
@@ -93,7 +93,7 @@ if ($jmolfiletype === "cif" ) {
     $dropmenu = 'SimpleBio';
 } else if ($jmolfiletype === "pdb" || $jmolfiletype === "mcif") {
     $loadscript = 'set pdbAddHydrogens true; load '.$pathname.'; calculate hbonds; hbonds off; ssbonds off; ';
-    $loadscript = $loadscript.'display not water; select protein or nucleic; cartoons only; color structure; ';
+    $loadscript = $loadscript.'select protein or nucleic; cartoons only; color structure; ';
     $loadscript = $loadscript.'set hbondsBackbone TRUE; set ssbondsbackbone TRUE; select *;';
     $menu = 'SimpleBio.mnu';
     $dropmenu = 'SimpleBio';


### PR DESCRIPTION
As per investigations for https://github.com/geoffrowland/moodle-filter_jmol/issues/21 water molecule is currenlty blocked from displaaying on inital load.

This pull request removes the block.