### PR TITLE
Fix iframe Reflected Cross-Site Scripting bug

### DIFF
--- a/iframe.php
+++ b/iframe.php
@@ -52,7 +52,7 @@ if (strpos($browser, 'firefox')) {
     $bversion = str_replace('.', '', $bversion);
 }
 $wwwroot = $CFG->wwwroot;
-$url = $_GET['u'];
+$url = required_param('u', PARAM_URL);
 $pathname = $url;
 $filestem = $_GET['n'];
 $filetype = $_GET['f'];

--- a/js/jsmol/php/jsmol.php
+++ b/js/jsmol/php/jsmol.php
@@ -166,7 +166,7 @@ if ($call == "getInfoFromDatabase") {
 ob_start();
 
  if ($myerror != "") {
-   $output = $myerror;
+   $output = htmlspecialchars($myerror);
  } else { 
    if ($imagedata != "") {
   	$output = $imagedata;


### PR DESCRIPTION
Reflected Cross-Site Scripting Risk: High
The moodle websites are vulnerable to reflected cross-site scripting. This allows an attacker to take control of the user's browser. For reflected cross-site scripting to be exploited by an attacker, a victim needs to visit a specially crafted link created by the attacker, for example sent to the victim in an email. 
The following example shows that malicious JavaScript code that be injected via the "u" parameter on the URLs below.
https://yourmoodlehere.com/filter/jmol/iframe.php?DEFER=1&u="};alert(document.cookie);//
https://yourmoodlehere.com/filter/jmol/iframe.php?DEFER=1&u="};alert(document.cookie);//

I couldn't see any other params to iframe.php that had the same issue. Have fixed the u param to use moodle code so input is properly sanitised... ideally all uses of $_GET in this script should be replaced with Moodle code (I left these alone).

Second commit fixes similar issue in jsmol php error message, as pull request in jsmol repo https://github.com/BobHanson/Jmol-SwingJS/pull/24 