### PR TITLE
Block all access to jsmol.php

### DIFF
--- a/js/jsmol/php/jsmol.php
+++ b/js/jsmol/php/jsmol.php
@@ -1,5 +1,7 @@
 <?php
 
+die; // CATALYST CUSTOM - WR343674.
+
 // jsmol.php
 // Bob Hanson hansonr@stolaf.edu 1/11/2013
 //


### PR DESCRIPTION
jsmol.php functions as a sort of cross-origin proxy with significantly more access to Moodle than it should have: under the right conditions it can leak the contents of PHP files including config.php, as well as attempt to save files to the local file system for later exploitation. Logs do not suggest it is currently being used, so simply break all the functionality until we can sanitise it.


Sanitising may have already happened to some extent in https://github.com/geoffrowland/moodle-filter_jmol/pull/31/files#diff-e247e7eae76f0c5ce4d55195e1b30590e23f070488b9d4d5acf2e86de16d684cR169 but if not used and such a security risk, worth applying this